### PR TITLE
Fix login helper and diasable app logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ function startAllApps (done) {
     app.proc = spawn('npm', ['start'], {cwd: app.root, env: env})
     console.log(app.name, 'starting')
     app.proc.stdout.on('data', function (data) {
-      if (app.ready || !app.waitFor) console.log(app.name, data.toString('utf8'))
+      // uncomment if you need all the app logs. They typically distract from the nightwatch log.
+      // if (app.ready || !app.waitFor) console.log(app.name, data.toString('utf8'))
       if (data.toString('utf8').indexOf(app.waitFor) === -1) return
       app.ready = true
       console.log(chalk.green(app.name, 'ready'))

--- a/test/helpers/bo/login.js
+++ b/test/helpers/bo/login.js
@@ -13,5 +13,5 @@ module.exports = function (browser) {
     .click('#signIn')
     .waitForElementVisible('#submit_approve_access:not([disabled])', 5000)
     .click('#submit_approve_access')
-    .waitForElementVisible('body', 1000)
+    .pause(1000)
 }


### PR DESCRIPTION
For some reason waiting for body after G auth fails, but a pause is ok.

The app logging is now hidden, as it distracts from the nightwatch report.
